### PR TITLE
fix(lsp): emit an empty semantic-tokens legend as [] not null

### DIFF
--- a/internal/lsp/capabilities.go
+++ b/internal/lsp/capabilities.go
@@ -50,11 +50,14 @@ func (s *Server) serverCapabilities() map[string]interface{} {
 	}
 	if len(s.semanticTokensProviders) > 0 && s.featureEnabled("semanticTokens") {
 		capabilities["semanticTokensProvider"] = map[string]interface{}{
+			// The legend slices must marshal to JSON arrays even when empty.
+			// appending onto []string(nil) keeps a nil slice when the source
+			// list is empty, and nil marshals to null, which strictly typed
+			// clients reject: SemanticTokensLegend.tokenModifiers is a
+			// required string[] in the specification.
 			"legend": protocol.SemanticTokensLegend{
-				TokenTypes: append([]string(nil), protocol.SemanticTokenTypes...),
-				TokenModifiers: append(
-					[]string(nil), protocol.SemanticTokenModifiers...,
-				),
+				TokenTypes:     append([]string{}, protocol.SemanticTokenTypes...),
+				TokenModifiers: append([]string{}, protocol.SemanticTokenModifiers...),
 			},
 			"full":  true,
 			"range": false,

--- a/internal/lsp/workspace_test.go
+++ b/internal/lsp/workspace_test.go
@@ -215,6 +215,12 @@ func TestInitializeAdvertisesTwigFileRenameEdits(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, protocol.SemanticTokenTypes, legend.TokenTypes)
 	require.Empty(t, legend.TokenModifiers)
+	// require.Empty passes for a nil slice too, so assert the wire format.
+	// A nil slice marshals to null, and clients that decode the legend into a
+	// required string[] reject the entire initialize response.
+	encodedLegend, err := json.Marshal(legend)
+	require.NoError(t, err)
+	require.Contains(t, string(encodedLegend), `"tokenModifiers":[]`)
 	require.Equal(t, true, semanticTokens["full"])
 	require.Equal(t, false, semanticTokens["range"])
 }


### PR DESCRIPTION
## Problem

Editors whose LSP client decodes the initialize response into the protocol's
declared types cannot use the language server at all. Zed fails with:

```
initializing server shopware-lsp, id 9: failed to deserialize response:
data did not match any variant of untagged enum SemanticTokensServerCapabilities
at line 1 column 2926
```

This is not a degraded semantic-highlighting experience. The whole
`initialize` response is rejected, so completions, hover, definitions,
diagnostics, and code actions never come up.

## Cause

`ServerCapabilities` built the semantic-tokens legend like this:

```go
TokenTypes:     append([]string(nil), protocol.SemanticTokenTypes...),
TokenModifiers: append([]string(nil), protocol.SemanticTokenModifiers...),
```

`protocol.SemanticTokenModifiers` is currently empty, and appending zero
elements onto `[]string(nil)` yields a nil slice, which marshals to `null`:

```json
"semanticTokensProvider": {
  "full": true,
  "legend": {
    "tokenTypes": ["keyword","property","type","variable","string","number","class","function","operator"],
    "tokenModifiers": null
  },
  "range": false
}
```

`SemanticTokensLegend.tokenModifiers` is a required `string[]` in the
specification, and the struct tag here declares it as such too. VS Code's
JavaScript client coerces the `null` and carries on, which is why this went
unnoticed. `TokenTypes` uses the identical pattern but its source list is
non-empty, so it never produced a nil slice.

This was the only `null` anywhere in the initialize result.

## Fix

Build both legend slices on `[]string{}` so they marshal to arrays whether or
not the source list is populated. `TokenTypes` is included even though it is
not currently affected, because leaving the nil-preserving idiom in place means
the bug returns the moment that list is emptied or made conditional.

## Test

`workspace_test.go` already asserted the legend, but with
`require.Empty(t, legend.TokenModifiers)`, which passes for a nil slice and so
could not catch this. It now also asserts the marshalled form, which is the
thing clients actually consume.

Reverting the production change alone makes it fail:

```
Error: "{"tokenTypes":[...],"tokenModifiers":null}" does not contain "\"tokenModifiers\":[]"
Test:  TestInitializeAdvertisesTwigFileRenameEdits
```

## Verification

- `go test ./internal/lsp/...` passes.
- `golangci-lint run ./internal/lsp/...` reports 0 issues.
- `gofmt` and `go vet` clean.
- Built `darwin/arm64` and drove a real `initialize` handshake against a
  Shopware checkout. Before: `"tokenModifiers":null`. After:
  `"tokenModifiers":[]`, with the 9 token types unchanged. Zed then attaches
  the server successfully.

One local caveat, not a regression from this change:
`TestProjectRouteIndexerReloadsCompiledRoutes` in `internal/symfony` fails on
my macOS machine ("Condition never satisfied", a watcher-timing assertion). It
fails identically on unmodified `49af967`, and `validate / Test` was green on
Linux CI for that same commit (run 34091565310), so it looks macOS-specific and
is unrelated to the legend.

## Note on CI

No checks report on this PR. `tests.yml` only triggers on `pull_request:
branches: [main]`, and this targets `feat/next-gen`, so no workflow matches.
`vsix-preview.yml` covers `feat/next-gen` on `push`, meaning validation happens
after merge rather than before it, and its `workflow_dispatch` entry point also
carries the `publish` job, so it is not a safe way to pre-validate a branch.

Adding `feat/next-gen` to the `pull_request` branches list in `tests.yml` would
give PRs into that branch the same gate `main` has. I have left that out of
this PR: it is a separate concern, and my token lacks the `workflow` scope
needed to push workflow changes. Happy to open it separately if you want it.
