### PR TITLE
ci: gate pull requests into feat/next-gen

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
       - '.golangci.yml'
       - '.github/workflows/tests.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ main, feat/next-gen ]
     paths:
       - '**.go'
       - 'go.mod'


### PR DESCRIPTION
## Problem

Pull requests targeting `feat/next-gen` report no checks at all.

`tests.yml` triggers on `pull_request: branches: [ main ]`. Since `feat/next-gen`
is where the 0.3.x work happens, that is exactly the branch without a gate.

#59 is a concrete example: it changed `internal/lsp/capabilities.go` and a test,
and merged with zero checks reported. Nothing caught it either way, which is the
same path a real break would take.

## Why the existing coverage does not close it

`vsix-preview.yml` does call `tests.yml` on push to `feat/next-gen`, but that
runs *after* merge, so a failure lands on the branch rather than on the PR.

Its `workflow_dispatch` entry point is not a usable substitute either: the job
graph ends in `publish`, which runs `vsce publish` and `ovsx publish`, so
dispatching it to pre-validate a branch would push a pre-release to both
marketplaces.

## Change

Add `feat/next-gen` to the `pull_request` branches list. One line.

The `paths` filter is untouched, so PRs that do not touch Go, `go.mod`,
`go.sum`, `mise.toml`, `.golangci.yml`, or this workflow still skip the run.
The `push` trigger is left alone, since `vsix-preview.yml` already covers
pushes to that branch.

For `pull_request`, GitHub evaluates the workflow file from the base branch,
which is why this targets `feat/next-gen` rather than `main`.

## Possible follow-up, not included

`tests.yml` has no `workflow_dispatch` trigger, so there is no safe way to run
the suite manually against an arbitrary branch. Adding one would give that
without touching the publish path, since `tests.yml` has no publish job. Left
out to keep this to a single concern.
