### PR TITLE
docs: correct the documented return values for edit-producing commands

### DIFF
--- a/LSP.md
+++ b/LSP.md
@@ -61,8 +61,8 @@ document snapshot; no custom request is required.
     "snippets": [ { "path": string, "name": string, "value": string } ]
   }
   ```
-* **Action:** Adds the provided snippet value to the given JSON files, reindexes them and publishes diagnostics for the original document.
-* **Returns:** `null`
+* **Action:** Builds the edit that adds the provided snippet value to the given JSON files. The server writes nothing itself; the client must apply the returned edit.
+* **Returns:** `{ "edit": WorkspaceEdit }`
 
 ### `shopware/snippet/storefront/all`
 * **Parameters:** none
@@ -83,8 +83,8 @@ document snapshot; no custom request is required.
     "snippets": [ { "path": string, "name": string, "value": string } ]
   }
   ```
-* **Action:** Adds the provided snippet value to the given admin JSON files, reindexes them and publishes diagnostics for the original document.
-* **Returns:** `null`
+* **Action:** Builds the edit that adds the provided snippet value to the given admin JSON files. The server writes nothing itself; the client must apply the returned edit.
+* **Returns:** `{ "edit": WorkspaceEdit }`
 
 ### `shopware/snippet/admin/all`
 * **Parameters:** none
@@ -96,8 +96,8 @@ document snapshot; no custom request is required.
   ```json
   { "textUri": string, "blockName": string, "extension": string }
   ```
-* **Action:** Creates or updates a Twig template in the selected extension so that it extends the given block. A new file is created if necessary and the block is inserted.
-* **Returns:** on success `{ "uri": string, "line": number }`; otherwise an error object with `code` and `message`.
+* **Action:** Builds the edit that creates or updates a Twig template in the selected extension so that it extends the given block, creating the file if necessary. The server writes nothing itself; the client must apply the returned edit.
+* **Returns:** on success `{ "uri": string, "line": number, "edit": WorkspaceEdit }`, where `uri` and `line` locate the block once the edit has been applied; otherwise an error object with `code` and `message`.
 
 ## Notifications
 


### PR DESCRIPTION
## Problem

`LSP.md` understates the return values of three commands, and a client written
against it silently does nothing.

| Command | Documented | Actual |
|---|---|---|
| `shopware/snippet/storefront/create` | `null` | `{ edit: WorkspaceEdit }` |
| `shopware/snippet/admin/create` | `null` | `{ edit: WorkspaceEdit }` |
| `shopware/twig/extendBlock` | `{ uri, line }` | `{ uri, line, edit: WorkspaceEdit }` |

In each case the server builds a `WorkspaceEdit` and writes nothing itself:

- `createSnippets` in `internal/lsp/commands/snippet_command.go` ends with
  `return EditResponse{Edit: edit}, nil`.
- `extendBlock` in `internal/lsp/commands/twig_command.go` returns
  `map[string]any{"uri": ..., "line": ..., "edit": edit}`.

The doc also describes both snippet commands as reindexing and publishing
diagnostics, which reads as though the write already happened.

## Why it matters

The failure is silent, not loud. I hit this writing a non-VS-Code client: the
command returned without error, my client reported success, and the snippet
file was still `{}`. Nothing in the response looked wrong, because the doc said
`null` was the expected success value.

`extendBlock` is worse in a way: it *does* return `{uri, line}` exactly as
documented, so the response validates against the doc while the only
consequential field is missing from it.

## Change

Documentation only. Corrects the three `Returns:` lines and rewords the
actions to say the client must apply the returned edit.
