### PR TITLE
fix(diagnostics): treat sibling namespaces as the same Composer package

### DIFF
--- a/internal/lsp/diagnostics/shopware_php_semantic.go
+++ b/internal/lsp/diagnostics/shopware_php_semantic.go
@@ -583,11 +583,37 @@ func phpNamespace(name string) string {
 	return ""
 }
 
+// samePHPNamespacePackage reports whether two namespaces belong to the same
+// Composer package.
+//
+// A prefix comparison alone is not enough. Shopware\Core\Checkout\Cart\Hook and
+// Shopware\Core\Framework\Script\Execution are both shopware/core, yet neither
+// is a prefix of the other, so sibling subtrees of one package looked like
+// separate packages and every first-party use of an @internal class was
+// reported. Compare the Vendor\Package root as well, which is the PSR-4 layout
+// Composer packages follow.
 func samePHPNamespacePackage(left, right string) bool {
 	left = trimPHPName(left)
 	right = trimPHPName(right)
-	return left == right || left != "" && right != "" &&
-		(strings.HasPrefix(left, right+"\\") || strings.HasPrefix(right, left+"\\"))
+	if left == "" || right == "" {
+		return left == right
+	}
+	if left == right ||
+		strings.HasPrefix(left, right+"\\") ||
+		strings.HasPrefix(right, left+"\\") {
+		return true
+	}
+	return phpPackageRoot(left) == phpPackageRoot(right)
+}
+
+// phpPackageRoot returns the Vendor\Package prefix of a namespace, or the whole
+// namespace when it has fewer than two segments.
+func phpPackageRoot(namespace string) string {
+	parts := strings.SplitN(namespace, "\\", 3)
+	if len(parts) < 2 {
+		return namespace
+	}
+	return parts[0] + "\\" + parts[1]
 }
 
 func insidePHPLoop(node *phpsyntax.Node) bool {

--- a/internal/lsp/diagnostics/shopware_php_semantic_test.go
+++ b/internal/lsp/diagnostics/shopware_php_semantic_test.go
@@ -235,3 +235,33 @@ class Core extends AbstractCore { public function getDecorated(): AbstractCore {
 	}
 	return phpIndex
 }
+
+func TestSamePHPNamespacePackageAcceptsSiblingSubtrees(t *testing.T) {
+	// Both namespaces are shopware/core. Neither is a prefix of the other,
+	// which is why prefix matching alone reported first-party use of @internal
+	// classes throughout the platform.
+	require.True(t, samePHPNamespacePackage(
+		`Shopware\Core\Checkout\Cart\Hook`,
+		`Shopware\Core\Framework\Script\Execution`,
+	))
+
+	// Prefix relationships keep working.
+	require.True(t, samePHPNamespacePackage(
+		`Shopware\Core\Framework`,
+		`Shopware\Core\Framework\Script`,
+	))
+	require.True(t, samePHPNamespacePackage(`Shopware\Core`, `Shopware\Core`))
+
+	// Separate packages stay separate, so the rule still protects plugins and
+	// still reports across the platform's own packages.
+	require.False(t, samePHPNamespacePackage(
+		`Swag\MyPlugin\Service`,
+		`Shopware\Core\Framework\Script\Execution`,
+	))
+	require.False(t, samePHPNamespacePackage(
+		`Shopware\Storefront\Framework`,
+		`Shopware\Core\Framework`,
+	))
+	require.False(t, samePHPNamespacePackage(`Shopware`, `Swag`))
+	require.False(t, samePHPNamespacePackage("", `Shopware\Core`))
+}


### PR DESCRIPTION
## Problem

`shopware.php.internal.class_extension` fires 87 times on a plain
`shopware/shopware` checkout, on the platform's own classes:

```
src/Core/Checkout/Cart/Hook/CartHook.php:23
  Class CartHook extends internal Shopware class
  Shopware\Core\Framework\Script\Execution\Hook; internal APIs are not extension points

src/Core/Checkout/Cart/Facade/CartFacadeHookFactory.php:16
  Class CartFacadeHookFactory extends internal Shopware class
  Shopware\Core\Framework\Script\Execution\Awareness\HookServiceFactory
```

`Hook` is an abstract base that core subclasses on purpose. `@internal` marks
it as not an extension point *for consumers of the package*, which is a rule
about third parties, not about the package itself.

**80 of the 87 are `Shopware\Core` extending `Shopware\Core`.**

## Cause

The exemption exists and already intends to cover this:

```go
return !samePHPNamespacePackage(sourceNamespace, targetNamespace)
```

but the predicate only accepts a prefix relationship:

```go
return left == right || left != "" && right != "" &&
    (strings.HasPrefix(left, right+"\\") || strings.HasPrefix(right, left+"\\"))
```

`Shopware\Core\Checkout\Cart\Hook` and
`Shopware\Core\Framework\Script\Execution` are both `shopware/core`, but
neither is a prefix of the other, so two subtrees of a single package read as
separate packages.

Worth noting that `internal/lsp/phpsemantic/completion_imports.go` solves the
same question properly, resolving the real package from the project model's
PSR-4 map and only falling back to this heuristic. Plumbing a `*project.Model`
into `shopwarePHPSemanticRun` would be the thorough fix; this PR stays with the
heuristic and just widens it to the `Vendor\Package` root.

## Change

Keep the prefix test and add a package-root comparison.

Deliberately conservative:

- Cross-package first-party extension still reports. `Shopware\Storefront` and
  `Shopware\Administration` reaching into `Shopware\Core` are the remaining 7,
  and whether those should be exempt is a separate judgement.
- A plugin namespace never shares a root with `Shopware\Core`, so the rule
  still does its job for the audience it was written for.

`internalShopwareUse` also backs the internal *method* and *function* rules, so
those gain the same first-party exemption, consistently.

## Test

`TestSamePHPNamespacePackageAcceptsSiblingSubtrees` covers the sibling case,
existing prefix relationships, plugin-to-Shopware, Storefront-to-Core, and
empty input. Reverting the production change fails it.

Verified against a checkout: 87 diagnostics become 7, and those 7 are exactly
the cross-package cases.
