### PR TITLE
fix(lsp): emit completion documentation and colour results in valid shapes

### DIFF
--- a/internal/lsp/color.go
+++ b/internal/lsp/color.go
@@ -13,15 +13,15 @@ func (s *Server) documentColors(
 	params *protocol.DocumentColorParams,
 ) ([]protocol.ColorInformation, error) {
 	if params == nil {
-		return nil, nil
+		return []protocol.ColorInformation{}, nil
 	}
 	document, ok := s.documentManager.GetDocument(params.TextDocument.URI)
 	if !ok {
-		return nil, nil
+		return []protocol.ColorInformation{}, nil
 	}
 	request := &DocumentColorRequest{DocumentColorParams: params, Document: document}
 	seen := make(map[protocol.Range]struct{})
-	var result []protocol.ColorInformation
+	result := []protocol.ColorInformation{}
 	for _, provider := range s.documentColorProviders {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -52,18 +52,18 @@ func (s *Server) colorPresentations(
 	params *protocol.ColorPresentationParams,
 ) ([]protocol.ColorPresentation, error) {
 	if params == nil {
-		return nil, nil
+		return []protocol.ColorPresentation{}, nil
 	}
 	document, ok := s.documentManager.GetDocument(params.TextDocument.URI)
 	if !ok {
-		return nil, nil
+		return []protocol.ColorPresentation{}, nil
 	}
 	request := &ColorPresentationRequest{
 		ColorPresentationParams: params,
 		Document:                document,
 	}
 	seen := make(map[string]struct{})
-	var result []protocol.ColorPresentation
+	result := []protocol.ColorPresentation{}
 	for _, provider := range s.documentColorProviders {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/internal/lsp/color_test.go
+++ b/internal/lsp/color_test.go
@@ -2,9 +2,11 @@ package lsp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/shopware/shopware-lsp/internal/lsp/protocol"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +102,59 @@ func TestColorPresentationsUseLiveDocumentAndDeduplicate(t *testing.T) {
 	require.NotNil(t, received)
 	require.Same(t, params, received.ColorPresentationParams)
 	require.Equal(t, 9, received.Document.Version)
+}
+
+// documentColor and colorPresentation are specified as arrays, with no null
+// permitted, unlike most requests. A nil slice marshals to null, which strict
+// clients reject outright: Zed logs "invalid type: null, expected a sequence"
+// and drops the response.
+func TestColorResponsesMarshalEmptyResultsAsArrays(t *testing.T) {
+	server := NewServer(nil, "", "test")
+	t.Cleanup(func() { require.NoError(t, server.CloseAll()) })
+	uri := "file:///workspace/component.scss"
+	server.documentManager.OpenDocument(uri, "$a: #000;", 1)
+	absent := protocol.TextDocumentIdentifier{URI: "file:///workspace/absent.scss"}
+	open := protocol.TextDocumentIdentifier{URI: uri}
+
+	requireEmptyJSONArray := func(t *testing.T, result any, err error) {
+		t.Helper()
+		require.NoError(t, err)
+		payload, marshalErr := json.Marshal(result)
+		require.NoError(t, marshalErr)
+		assert.Equal(t, "[]", string(payload))
+	}
+
+	t.Run("colors with no provider registered", func(t *testing.T) {
+		result, err := server.documentColors(context.Background(),
+			&protocol.DocumentColorParams{TextDocument: open})
+		requireEmptyJSONArray(t, result, err)
+	})
+
+	t.Run("colors for a document that is not open", func(t *testing.T) {
+		result, err := server.documentColors(context.Background(),
+			&protocol.DocumentColorParams{TextDocument: absent})
+		requireEmptyJSONArray(t, result, err)
+	})
+
+	t.Run("colors without params", func(t *testing.T) {
+		result, err := server.documentColors(context.Background(), nil)
+		requireEmptyJSONArray(t, result, err)
+	})
+
+	t.Run("presentations with no provider registered", func(t *testing.T) {
+		result, err := server.colorPresentations(context.Background(),
+			&protocol.ColorPresentationParams{TextDocument: open})
+		requireEmptyJSONArray(t, result, err)
+	})
+
+	t.Run("presentations for a document that is not open", func(t *testing.T) {
+		result, err := server.colorPresentations(context.Background(),
+			&protocol.ColorPresentationParams{TextDocument: absent})
+		requireEmptyJSONArray(t, result, err)
+	})
+
+	t.Run("presentations without params", func(t *testing.T) {
+		result, err := server.colorPresentations(context.Background(), nil)
+		requireEmptyJSONArray(t, result, err)
+	})
 }

--- a/internal/lsp/protocol/completion.go
+++ b/internal/lsp/protocol/completion.go
@@ -149,7 +149,7 @@ type CompletionItem struct {
 	Documentation struct {
 		Kind  string `json:"kind"`
 		Value string `json:"value"`
-	} `json:"documentation,omitempty"`
+	} `json:"documentation,omitzero"`
 
 	// Indicates if this item is deprecated
 	Deprecated bool `json:"deprecated,omitempty"`

--- a/internal/lsp/protocol/completion_test.go
+++ b/internal/lsp/protocol/completion_test.go
@@ -1,0 +1,62 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An empty documentation object is not a valid Documentation value: kind is a
+// MarkupKind, so "" matches neither permitted variant. Clients that decode
+// into a typed union reject the enclosing response, discarding every item in
+// the list rather than just the documentation of one.
+func TestCompletionItemOmitsUnsetDocumentation(t *testing.T) {
+	payload, err := json.Marshal(CompletionItem{
+		Label: "BREADCRUMB_REWORK",
+		Kind:  int(FunctionCompletion),
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "documentation")
+	assert.JSONEq(t, `{"label":"BREADCRUMB_REWORK","kind":3}`, string(payload))
+}
+
+func TestCompletionItemKeepsPopulatedDocumentation(t *testing.T) {
+	item := CompletionItem{Label: "isActive", Kind: int(MethodCompletion)}
+	item.Documentation.Kind = string(Markdown)
+	item.Documentation.Value = "Determines whether a feature is active."
+
+	payload, err := json.Marshal(item)
+	require.NoError(t, err)
+	assert.JSONEq(
+		t,
+		`{"label":"isActive","kind":2,"documentation":{"kind":"markdown",`+
+			`"value":"Determines whether a feature is active."}}`,
+		string(payload),
+	)
+}
+
+// A list mixing documented and undocumented items is the common case, and the
+// one that used to fail: a single item without a docblock was enough to make
+// the whole response undecodable.
+func TestCompletionListMixesDocumentedAndUndocumentedItems(t *testing.T) {
+	documented := CompletionItem{Label: "isActive"}
+	documented.Documentation.Kind = string(PlainText)
+	documented.Documentation.Value = "Whether a feature is active."
+
+	payload, err := json.Marshal(CompletionList{
+		Items: []CompletionItem{{Label: "CACHE_REWORK"}, documented},
+	})
+	require.NoError(t, err)
+
+	var decoded struct {
+		Items []map[string]json.RawMessage `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	require.Len(t, decoded.Items, 2)
+
+	_, undocumentedHasField := decoded.Items[0]["documentation"]
+	assert.False(t, undocumentedHasField, "undocumented item must omit the field entirely")
+	assert.Contains(t, decoded.Items[1], "documentation")
+}


### PR DESCRIPTION
Two response shapes that strict LSP clients reject. Both are invisible in VS Code, because `vscode-languageclient` does not validate them, and both were found while wiring the server into Zed.

## 1. Completion items always emit `documentation: {"kind": ""}`

Zed drops **every** completion from the server — not a subset, the whole response, on every request, in every language:

```
ERROR [lsp] failed to deserialize response from language server:
  data did not match any variant of untagged enum Documentation
WARN  [project::lsp_store] Get completion via shopware-lsp failed: failed to deserialize response
```

`CompletionItem.Documentation` is an inline struct tagged `omitempty`, and `omitempty` is a no-op for struct-typed fields — it applies only to basic types, maps, slices, pointers and interfaces. So an item without a docblock serialized as:

```json
{ "label": "BREADCRUMB_REWORK", "kind": 3,
  "documentation": { "kind": "", "value": "" } }
```

`documentation.kind` is a `MarkupKind`, so `""` is not a permitted value, and `Documentation` is `string | MarkupContent` — an untagged union in typed clients. Both arms fail, and the failure is at the *response* level, so one undocumented item discards the entire list. In practice that is always: in the `Feature::` member list, 22 of 25 items had no docblock.

The provider was already correct — `phpsemantic/completion.go` only populates the field when `symbol.DocSummary() != ""`. The field shipped regardless of that guard.

`go.mod` is on `go 1.27.0`, so `omitzero` (Go 1.24+) is available and *does* apply to structs. That keeps the fix to one word and leaves the ~150 sites that assign `item.Documentation.*` untouched. `*MarkupContent` with `omitempty` would also work — matching `protocol/signature_help.go`, which uses that shape and is unaffected — but it would touch every call site.

Reproducible without an editor:

```bash
shopware-lsp -root /path/to/shopware completion path/to/File.php:11:35
```

## 2. `documentColor` and `colorPresentation` return `null`

```
ERROR [lsp] failed to deserialize response from language server:
  invalid type: null, expected a sequence. response from language server: "null"
WARN  [project::lsp_store] Document color via shopware-lsp failed: failed to deserialize response
```

Unlike most requests, both are specified as arrays with no `null` permitted. Each handler built its result from a `var result []T` nil slice and returned `nil` from its two early exits, all of which marshal to `null`. Fires on every edit of any file the SCSS colour provider applies to; the consequence is limited to missing swatches, but `colorProvider: true` is advertised in `initialize`.

```bash
shopware-lsp -root /path/to/shopware colors path/to/any.scss
# before: null      after: []
```

## Related, and the sweep

Same family as #59, where `legend.tokenModifiers` emitted `null` in place of an array and stopped Zed initializing at all. Since that makes three, I swept `internal/lsp/protocol` for other outbound fields relying on `omitempty` where it does not apply. The remaining hits are all client→server types the server only deserializes, so the tag is inert there. One outbound exception: `FileOperationPattern.Options` always emits `"options": {}` in the initialize result — a valid empty object, accepted by Zed, so left alone rather than widening this diff.

## Tests

- `protocol/completion_test.go` — the field is omitted when unset, preserved when populated, and a list mixing documented and undocumented items stays decodable. That last one is the case that used to fail.
- `color_test.go` — all six empty paths across both handlers (no provider, unopened document, nil params) marshal to `[]`.

Each test fails on the parent commit and passes with the fix. `go test ./internal/lsp/...`, `go test -race` on both changed packages, `gofmt` and `golangci-lint run ./internal/lsp/...` are clean.

## Verification in a client

Built from this branch and pointed Zed at it against a `shopware/shopware` trunk checkout: completions populate where previously nothing appeared at all, and the `documentColor` errors are gone from the log.
