### PR TITLE
fix(php): bound self and static substitution by node count

### DIFF
--- a/internal/php/inference/helpers.go
+++ b/internal/php/inference/helpers.go
@@ -305,6 +305,15 @@ func resolveSpecialType(
 // enough headroom for valid chains while bounding adversarial type graphs.
 const maxSpecialTypeDepth = 128
 
+// Depth alone does not bound substitution cost. `self` and `static` expand to
+// the complete receiver, and a PHPDoc conditional names the placeholder once
+// per branch: Symfony's ArrayNodeDefinition::prototype() mentions `$this` nine
+// times, so one fluent link multiplies the inferred type ninefold while adding
+// a single level of nesting. Chaining such links, as Symfony's Configuration
+// classes do, grows the graph exponentially while staying far below
+// maxSpecialTypeDepth. Real workspaces resolve well under two thousand nodes.
+const maxSpecialTypeNodes = 4096
+
 func resolveSpecialTypeAtDepth(
 	value,
 	receiver,
@@ -563,10 +572,18 @@ func copyShapeFields(value types.Type) []types.ShapeField {
 	return result
 }
 
+// applySpecialTypeArguments substitutes a resolved `self` or `static`. The
+// whole base is copied into the placeholder, so refusing an oversized base
+// breaks a fluent chain instead of letting each link multiply the previous
+// one. Unknown matches how callers already treat a depth-truncated result, so
+// a later parent-return call cannot look definite.
 func applySpecialTypeArguments(
 	base types.Type,
 	special types.Type,
 ) types.Type {
+	if exceedsSpecialTypeNodes(base, maxSpecialTypeNodes) {
+		return types.Unknown()
+	}
 	argumentCount := special.ArgumentCount()
 	if argumentCount == 0 || base.Kind() != types.ObjectKind ||
 		base.Name() == "" {
@@ -577,6 +594,44 @@ func applySpecialTypeArguments(
 		arguments[index] = special.Argument(index)
 	}
 	return types.Named(base.Name(), arguments...)
+}
+
+// exceedsSpecialTypeNodes reports whether value holds more than limit nodes.
+// Counting stops at the limit so an already oversized graph cannot make the
+// guard itself expensive.
+func exceedsSpecialTypeNodes(value types.Type, limit int) bool {
+	return countSpecialTypeNodes(value, 0, limit) > limit
+}
+
+func countSpecialTypeNodes(value types.Type, counted, limit int) int {
+	counted++
+	if counted > limit {
+		return counted
+	}
+	for index := 0; index < value.ArgumentCount(); index++ {
+		counted = countSpecialTypeNodes(value.Argument(index), counted, limit)
+		if counted > limit {
+			return counted
+		}
+	}
+	for index := 0; index < value.ParameterCount(); index++ {
+		counted = countSpecialTypeNodes(
+			value.Parameter(index).Type, counted, limit,
+		)
+		if counted > limit {
+			return counted
+		}
+	}
+	for index := 0; index < value.FieldCount(); index++ {
+		counted = countSpecialTypeNodes(value.Field(index).Type, counted, limit)
+		if counted > limit {
+			return counted
+		}
+	}
+	if value.Kind() == types.CallableKind {
+		counted = countSpecialTypeNodes(value.Result(), counted, limit)
+	}
+	return counted
 }
 
 func joinTypes(relations types.Relations, values []types.Type) types.Type {

--- a/internal/php/inference/inference_test.go
+++ b/internal/php/inference/inference_test.go
@@ -3703,6 +3703,46 @@ func TestResolveSpecialTypeBoundsAdversarialNesting(t *testing.T) {
 	require.True(t, resolved.IsUnknown())
 }
 
+func TestResolveSpecialTypeBoundsFluentReceiverGrowth(t *testing.T) {
+	t.Parallel()
+
+	// A PHPDoc conditional names `$this` once per branch, so every link of a
+	// fluent chain copies the whole receiver into each of them. Symfony's
+	// ArrayNodeDefinition::prototype() has nine branches and its Configuration
+	// classes chain dozens of calls, which multiplies the inferred type far
+	// beyond any depth bound.
+	branches := make([]types.Type, 0, 9)
+	for index := range 9 {
+		branches = append(branches, types.Named(
+			"NodeDefinition"+strconv.Itoa(index),
+			types.Static(),
+		))
+	}
+	declared := types.Union(branches...)
+
+	receiver := types.Named("ArrayNodeDefinition")
+	for range 40 {
+		receiver = resolveSpecialType(declared, receiver, receiver)
+		require.False(
+			t,
+			exceedsSpecialTypeNodes(receiver, 16*maxSpecialTypeNodes),
+			"one fluent link must not grow the receiver without bound",
+		)
+	}
+}
+
+func TestResolveSpecialTypeSubstitutesModestReceivers(t *testing.T) {
+	t.Parallel()
+
+	receiver := types.Named("Receiver")
+	resolved := resolveSpecialType(
+		types.Named("Builder", types.Static()),
+		receiver,
+		types.Named("Current"),
+	)
+	require.True(t, types.Named("Builder", receiver).Equal(resolved))
+}
+
 func TestUntypedMagicMethodParameterAcceptsTypedArray(t *testing.T) {
 	t.Parallel()
 	source := `<?php


### PR DESCRIPTION
## What breaks

Indexing a workspace that contains `symfony/framework-bundle` grows to over 20 GB of resident memory within seconds, and the OS kills the language server. The log stops after `Found N files to index` and the editor's indexing progress never ends, because the process that would have finished it is gone.

Reproduced on a 12325-file project (`ucp-php-sdk`), RSS sampled once per second:

```
0.3 GB -> 9.8 GB -> 22.0 GB -> 23.9 GB -> killed
```

A heap profile taken at 23.9 GB attributes 98% of the live heap to one path:

```
inference.(*functionState).inferCall.func2
  -> inference.resolveMemberSpecialTypes        13875MB (97.1%)
    -> inference.resolveSpecialType (inline)
      -> strings.(*Builder).grow                14006MB (98.0%)
```

## Why

Resolving a member call substitutes the complete receiver into every `self` or `static` occurrence of the declared type. A PHPDoc conditional names the placeholder once per branch. `ArrayNodeDefinition::prototype()` has nine:

```php
/**
 * @return (
 *    T is 'array' ? ArrayNodeDefinition<$this>
 *    : (T is 'variable' ? VariableNodeDefinition<$this>
 *    ... five more ...
 *    : (T is 'enum' ? EnumNodeDefinition<$this>
 *    : NodeDefinition<$this>)))))))
 * )
 */
```

So one fluent link multiplies the inferred type ninefold while adding a single level of nesting. `maxSpecialTypeDepth` bounds nesting, not size, so it never fires. `Configuration.php` chains dozens of such calls in one expression.

Node counts instrumented along one chain in that file:

| call | receiver | result |
|---|---|---|
| `arrayNode()` | 2933 | 2934 |
| `prototype()` | 2934 | 26439 |
| `end()` | 2935 | 55746 |
| `end()` | 55746 | 111785 |

`finishType` caches canonical text for every constructed conditional, union and intersection node, so each step also renders the whole expanded tree — which is where the memory actually goes.

## Why it looks intermittent

Inference resolves against the persisted workspace graph loaded at startup. A genuinely cold cache has no Symfony Config symbols in it, `VisitMethods` finds nothing, and the run survives. Once those symbols are on disk, the chain resolves. A first index succeeds; a later full re-index against the warm graph does not.

The most common way to end up doing a full re-index against a warm graph is an interrupted run, which is a separate defect — see #67. This change is what stops the crash itself.

## The change

Refuse to substitute a base that already exceeds `maxSpecialTypeNodes` and yield `Unknown` instead, which callers already treat as truncation exactly as they do the depth bound. That breaks the chain at the first oversized link, so every step stays bounded by the declared type rather than by the previous step.

The guard sits inside `applySpecialTypeArguments`, which only runs where a substitution actually happens, so the ordinary composite path pays nothing:

```
BenchmarkResolveOrdinaryCompositeType   before  14.9 ns/op  0 B/op  0 allocs/op
BenchmarkResolveOrdinaryCompositeType   after   14.6 ns/op  0 B/op  0 allocs/op
```

An earlier revision guarded in `resolveSpecialType` instead and cost 21.5 ns/op.

The 4096 ceiling is far above anything real. Over the same instrumented run, p50 was 241 nodes and p90 was 1873; the next observed values are 26439 and up.

## Verification

Against the exact cache state that killed the server at 23.9 GB:

```
Indexed 12325 files (61.6 MiB) with 30 indexers in 10.67s
peak RSS 0.85 GB
```

`TestResolveSpecialTypeBoundsFluentReceiverGrowth` builds a nine-branch union of `static` and chains it forty times; it fails at iteration six without the change. `TestResolveSpecialTypeSubstitutesModestReceivers` pins that ordinary substitution is unaffected.

`./internal/...` passes except `TestProjectRouteIndexerReloadsCompiledRoutes` in `internal/symfony`, which fails identically on unmodified main (3/3 runs each way) and is unrelated to this change.

## Not addressed here

There is still no per-file ceiling, so a pathological file takes the whole process down rather than degrading to reduced precision for that one file. Worth considering separately.
