### PR TITLE
fix(indexer): publish tracked file states as the run progresses

### DIFF
--- a/internal/indexer/filescanner_core.go
+++ b/internal/indexer/filescanner_core.go
@@ -417,7 +417,13 @@ func (fs *FileScanner) IndexAll(ctx context.Context) error {
 	// the filesystem reconciliation that may invalidate it is still running.
 	// Request-time consumers use this marker to reject destructive previews
 	// against partial or stale indexes.
+	resuming := false
 	if fs.symbols != nil {
+		ready, err := fs.symbols.Ready(ctx)
+		if err != nil {
+			return fmt.Errorf("read workspace index readiness: %w", err)
+		}
+		resuming = !ready
 		if err := fs.symbols.SetReady(ctx, false); err != nil {
 			return fmt.Errorf("mark workspace indexes rebuilding: %w", err)
 		}
@@ -442,6 +448,9 @@ func (fs *FileScanner) IndexAll(ctx context.Context) error {
 
 	if fs.symbols != nil {
 		fs.symbols.BeginBulkPopulation()
+		if resuming {
+			fs.symbols.RequireBulkRebuild()
+		}
 	}
 	indexErr := fs.indexFiles(ctx, files, false, storedStates)
 	var symbolErr error

--- a/internal/indexer/filescanner_index.go
+++ b/internal/indexer/filescanner_index.go
@@ -29,11 +29,16 @@ type fileIndexRun struct {
 	files        []string
 	storedStates []storedFileState
 
-	resultMu      sync.Mutex
-	resultErrors  []error
-	updatedStates []fileState
-	skippedFiles  []skippedFileWork
-	batchIndexers []BatchIndexer
+	resultMu       sync.Mutex
+	resultErrors   []error
+	pendingStates  []fileState
+	publishedFiles int
+	skippedFiles   []skippedFileWork
+	batchIndexers  []BatchIndexer
+
+	// publishMu serialises the tracked-state writes, which go to a different
+	// database than the index mutations and therefore cannot join them.
+	publishMu sync.Mutex
 }
 
 func (fs *FileScanner) indexFiles(
@@ -63,10 +68,10 @@ func (fs *FileScanner) indexFiles(
 		ctx:          ctx,
 		files:        files,
 		storedStates: storedStates,
-		updatedStates: make(
+		pendingStates: make(
 			[]fileState,
 			0,
-			len(files),
+			min(len(files), fileStatePublishThreshold),
 		),
 	}
 	run.beginIndexerBatches()
@@ -83,11 +88,16 @@ func (fs *FileScanner) indexFiles(
 	if err := run.loadStoredStates(); err != nil {
 		return err
 	}
-	if !run.runWorkers() {
-		return errors.Join(run.resultErrors...)
+	cancelled := !run.runWorkers()
+	if !cancelled {
+		run.commitSkippedFiles()
 	}
-	run.commitSkippedFiles()
-	notifyUpdate = run.commitFileStates()
+	// Publishing also on the cancelled path is deliberate. Every state held
+	// here belongs to a batch whose index mutation already committed, so
+	// withholding it does not protect anything; it only tells the next run to
+	// redo work that is already durable.
+	run.publishFileStates()
+	notifyUpdate = run.publishedFiles > 0
 	return errors.Join(run.resultErrors...)
 }
 
@@ -124,7 +134,7 @@ func (run *fileIndexRun) finishIndexerBatches() error {
 	parsekit.ReleaseTransientBuffers()
 	clearMessagePackBuffers()
 	const largeBatchReclaimThreshold = 8192
-	if len(run.updatedStates) >= largeBatchReclaimThreshold {
+	if run.publishedFiles >= largeBatchReclaimThreshold {
 		// Cold workspace indexing leaves large parser, binder, and persistence
 		// slabs dead at the batch lifecycle boundary.
 		debug.FreeOSMemory()
@@ -299,8 +309,12 @@ func (run *fileIndexRun) processBatch(items []fileWork) {
 		return
 	}
 	run.resultMu.Lock()
-	run.updatedStates = append(run.updatedStates, successful...)
+	run.pendingStates = append(run.pendingStates, successful...)
+	due := len(run.pendingStates) >= fileStatePublishThreshold
 	run.resultMu.Unlock()
+	if due {
+		run.publishFileStates()
+	}
 }
 
 func (run *fileIndexRun) prepareBatch(items []fileWork) []preparedFileWork {
@@ -511,13 +525,42 @@ func preparedFileState(item preparedFileWork) fileState {
 	return fileState{path: item.file.Path, info: item.info}
 }
 
-func (run *fileIndexRun) commitFileStates() bool {
-	if len(run.updatedStates) == 0 {
-		return false
+// Tracked states are published in chunks rather than once per batch so the
+// extra transaction stays negligible against the indexing it records, while an
+// interrupted run loses at most this many files of progress.
+const fileStatePublishThreshold = 512
+
+// publishFileStates records the files whose index mutations already committed.
+// Index contents and tracked hashes live in two databases, so they cannot share
+// a transaction; publishing the hashes only after the whole run means an
+// interrupted index keeps every symbol it produced and forgets that it produced
+// them. The next run then rediscovers the entire workspace against a graph that
+// is already warm, which is both wasted work and a materially more expensive
+// shape of work than a cold index.
+func (run *fileIndexRun) publishFileStates() {
+	run.publishMu.Lock()
+	defer run.publishMu.Unlock()
+
+	run.resultMu.Lock()
+	pending := run.pendingStates
+	run.pendingStates = nil
+	run.resultMu.Unlock()
+	if len(pending) == 0 {
+		return
 	}
-	if err := run.scanner.updateFileStates(run.ctx, run.updatedStates); err != nil {
+
+	// The write is small, bounded, and describes work that is already durable.
+	// Letting a cancelled context abort it would discard exactly the progress
+	// this function exists to keep.
+	if err := run.scanner.updateFileStates(
+		context.WithoutCancel(run.ctx),
+		pending,
+	); err != nil {
 		run.recordError(fmt.Errorf("commit file state: %w", err))
-		return false
+		return
 	}
-	return true
+
+	run.resultMu.Lock()
+	run.publishedFiles += len(pending)
+	run.resultMu.Unlock()
 }

--- a/internal/indexer/filescanner_test.go
+++ b/internal/indexer/filescanner_test.go
@@ -261,6 +261,61 @@ func TestFileScannerUpdatesFileStatesInBatches(t *testing.T) {
 	}
 }
 
+func TestFileScanner_KeepsProgressWhenIndexingIsInterrupted(t *testing.T) {
+	tempDir := t.TempDir()
+	const fileCount = 120
+	for index := range fileCount {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(tempDir, fmt.Sprintf("source%03d.php", index)),
+			[]byte("<?php\n"),
+			0o644,
+		))
+	}
+
+	store, err := NewStore(filepath.Join(tempDir, "indexes.db"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	scanner, err := NewFileScanner(
+		tempDir,
+		filepath.Join(tempDir, "scanner.db"),
+		store,
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, scanner.Close()) }()
+	scanner.SetWorkerCount(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	indexer := &cancellingIndexer{after: 60, cancel: cancel}
+	scanner.AddIndexer(indexer)
+
+	require.Error(t, scanner.IndexAll(ctx))
+
+	interrupted, err := scanner.Stats(context.Background())
+	require.NoError(t, err)
+	require.Positive(
+		t,
+		interrupted.TrackedFiles,
+		"batches whose index mutation committed must stay tracked",
+	)
+	require.Less(t, interrupted.TrackedFiles, fileCount)
+
+	indexer.after = 0
+	before := indexer.count()
+	require.NoError(t, scanner.IndexAll(context.Background()))
+
+	completed, err := scanner.Stats(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, fileCount, completed.TrackedFiles)
+	require.Equal(
+		t,
+		fileCount-interrupted.TrackedFiles,
+		indexer.count()-before,
+		"the resuming run must only index what the interrupted one did not",
+	)
+}
+
 func TestFileScanner_RollsBackWorkspaceRepositoriesTogether(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "atomic.php")
@@ -1190,6 +1245,38 @@ func (i *supplementalMockIndexer) Index(file *ParsedFile) error {
 	}
 	return i.mockIndexer.Index(file)
 }
+
+// cancellingIndexer interrupts a run once it has seen a given number of files,
+// standing in for an editor shutdown or a killed process.
+type cancellingIndexer struct {
+	mu      sync.Mutex
+	indexed int
+	after   int
+	cancel  context.CancelFunc
+}
+
+func (i *cancellingIndexer) Index(*ParsedFile) error {
+	i.mu.Lock()
+	i.indexed++
+	reached := i.after > 0 && i.indexed == i.after
+	i.mu.Unlock()
+	if reached {
+		i.cancel()
+	}
+	return nil
+}
+
+func (i *cancellingIndexer) count() int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.indexed
+}
+
+func (i *cancellingIndexer) RemovedFiles([]string) error { return nil }
+func (i *cancellingIndexer) Name() string                { return "cancellingIndexer" }
+func (i *cancellingIndexer) ID() string                  { return "cancelling" }
+func (i *cancellingIndexer) Close() error                { return nil }
+func (i *cancellingIndexer) Clear() error                { return nil }
 
 type controlledIndexer struct {
 	err       error

--- a/internal/indexer/workspace_symbols.go
+++ b/internal/indexer/workspace_symbols.go
@@ -185,6 +185,16 @@ func (catalog *WorkspaceSymbolCatalog) BeginBulkPopulation() {
 	}
 }
 
+// RequireBulkRebuild forces the deferred FTS rebuild even when the run indexes
+// no file. A run that ends early leaves the catalog populated but unrebuilt;
+// because tracked states now survive that interruption, the resuming run can
+// legitimately have nothing left to index and would otherwise skip the repair.
+func (catalog *WorkspaceSymbolCatalog) RequireBulkRebuild() {
+	if catalog != nil {
+		catalog.bulkDirty.Store(true)
+	}
+}
+
 func (catalog *WorkspaceSymbolCatalog) EndBulkPopulation(
 	ctx context.Context,
 ) error {


### PR DESCRIPTION
## What breaks

Index contents and tracked file hashes live in two databases, so they cannot share a transaction. Contents were committed per batch, in `indexWithStore`; hashes were written once, after the last file, and the cancelled path skipped them entirely — deliberately, per the comment on `runWorkers`.

Any interruption therefore leaves a workspace that produced tens of thousands of symbols and recorded none of them. Killing a cold index of a 12325-file project six seconds in:

```
file_hashes rows: 0
indexes.db:       80,769,024 bytes
file_scanner.db:  12,288 bytes
```

The next run rediscovers every file and indexes it again. That is not merely a repeat of the cold run: the graph is now warm, so PHP inference resolves member chains it could not resolve the first time. On a workspace containing `symfony/framework-bundle` that is fatal (see #66), and because the crash leaves the cache in the same shape, it recurs on every start. The workspace never indexes again.

Worth stating plainly: an index-version bump and a configuration-fingerprint change both call `clearCacheDir`, and `-force` clears every indexer's data, so all of those degenerate to a clean cold index. An interrupted run is the only way into this state.

## The change

Publish states in chunks of 512 as batches commit, and publish the remainder on the cancelled path too. Every state held there belongs to a batch whose mutation already committed, so withholding it protects nothing — it only tells the next run to redo work that is already durable.

The write uses a context detached from cancellation. It is small, bounded, and records work that is already on disk; letting a cancelled context abort it would discard exactly the progress the change exists to keep.

`publishedFiles` replaces `len(updatedStates)` for the large-batch reclaim threshold and for the update notification, since the buffer is now drained as it goes.

### Workspace symbol FTS

A run that ends early also leaves the FTS unrebuilt. That was previously masked: the next run re-indexed everything, which set `bulkDirty` and rebuilt as a side effect. With resumption that mask goes away, and a resuming run can legitimately have nothing left to index. `RequireBulkRebuild` forces the rebuild when the catalog was not ready on entry, so the resuming run repairs it either way.

## Verification

Same interruption as above, SIGKILL five seconds into a cold index:

| | before | after |
|---|---|---|
| tracked files | 0 | 8995 |
| `indexes.db` | 80 MB | 68 MB |

The following run indexes only the remainder and completes in 6.6s.

With #66 also applied: killed at 3s leaves 2071 tracked files, and the next run finishes all 12325 in 8.9s at 0.30 GB peak.

`TestFileScanner_KeepsProgressWhenIndexingIsInterrupted` cancels a 120-file run mid-way and asserts both that committed batches stay tracked and that the resuming run indexes only what the interrupted one did not. Without the change it fails with `"0" is not positive` — the poisoned state, exactly.

`./internal/...` passes except `TestProjectRouteIndexerReloadsCompiledRoutes` in `internal/symfony`, which fails identically on unmodified main (3/3 runs each way) and is unrelated to this change.

## Not addressed here

Hashes and contents still cannot be committed atomically, so a crash between a mutation commit and the next publish re-indexes at most 512 files. `ATTACH`-ing `file_scanner.db` onto the store connection would close that window properly; that is a larger change and deliberately not in this PR.
