### PR TITLE
fix(symfony): resolve route names declared as class constants

### DIFF
--- a/internal/indexer/version.go
+++ b/internal/indexer/version.go
@@ -11,7 +11,7 @@ import (
 // IndexVersion is the current version of persisted index contents. Bump it
 // whenever a schema change or extraction-semantics change requires existing
 // workspace caches to be rebuilt.
-const IndexVersion = 171
+const IndexVersion = 172
 
 const versionFileName = "index_version"
 const configurationFingerprintFileName = "configuration_fingerprint"

--- a/internal/indexer/version_test.go
+++ b/internal/indexer/version_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCheckAndMigrateCache_FreshCache(t *testing.T) {
-	assert.Equal(t, 171, IndexVersion)
+	assert.Equal(t, 172, IndexVersion)
 	cacheDir := t.TempDir()
 
 	// Fresh cache should be marked as cleared (needs rebuild)

--- a/internal/lsp/diagnostics/route_diagnostics.go
+++ b/internal/lsp/diagnostics/route_diagnostics.go
@@ -112,6 +112,7 @@ func (p *RouteAnalyzer) missingRoutes(
 ) ([]lsp.Problem, error) {
 	var result []lsp.Problem
 	var candidateNames []string
+	resolvedNames := map[string]struct{}{}
 	candidatesLoaded := false
 	for _, literal := range literals {
 		if err := ctx.Err(); err != nil {
@@ -150,6 +151,11 @@ func (p *RouteAnalyzer) missingRoutes(
 			if queryErr != nil {
 				return nil, fmt.Errorf("query Symfony routes: %w", queryErr)
 			}
+			// Routes named by a class constant reach the index without a
+			// literal name, because the constant lives in another file.
+			// Resolve them here, where the PHP index is available, before
+			// deciding anything is missing.
+			allRoutes = symfony.ResolveConstantRouteNames(allRoutes, p.phpIndex)
 			seen := make(map[string]struct{}, len(allRoutes))
 			for _, route := range allRoutes {
 				if _, exists := seen[route.Name]; route.Name == "" || exists {
@@ -157,8 +163,12 @@ func (p *RouteAnalyzer) missingRoutes(
 				}
 				seen[route.Name] = struct{}{}
 				candidateNames = append(candidateNames, route.Name)
+				resolvedNames[route.Name] = struct{}{}
 			}
 			candidatesLoaded = true
+		}
+		if _, exists := resolvedNames[name]; exists {
+			continue
 		}
 		result = append(result, lsp.Problem{
 			Range:    valueNodeTextRange(literal, name),

--- a/internal/lsp/diagnostics/route_diagnostics.go
+++ b/internal/lsp/diagnostics/route_diagnostics.go
@@ -147,15 +147,14 @@ func (p *RouteAnalyzer) missingRoutes(
 			continue
 		}
 		if !candidatesLoaded {
-			allRoutes, queryErr := p.routeIndex.GetRoutes()
+			// Routes named by a class constant reach the index without a
+			// literal name, because the constant lives in another file. Ask
+			// for them here, where the PHP index is available to resolve
+			// them, before deciding anything is missing.
+			allRoutes, queryErr := p.routeIndex.ResolvedRoutes(p.phpIndex)
 			if queryErr != nil {
 				return nil, fmt.Errorf("query Symfony routes: %w", queryErr)
 			}
-			// Routes named by a class constant reach the index without a
-			// literal name, because the constant lives in another file.
-			// Resolve them here, where the PHP index is available, before
-			// deciding anything is missing.
-			allRoutes = symfony.ResolveConstantRouteNames(allRoutes, p.phpIndex)
 			seen := make(map[string]struct{}, len(allRoutes))
 			for _, route := range allRoutes {
 				if _, exists := seen[route.Name]; route.Name == "" || exists {

--- a/internal/parser/php/query/query.go
+++ b/internal/parser/php/query/query.go
@@ -738,7 +738,14 @@ func ArgumentExpression(node *syntax.Node, index int) *syntax.Node {
 // Unlike ArgumentExpression it also preserves parser-recovered composite
 // expressions such as Foo::class . '.inner'.
 func ArgumentValueText(node *syntax.Node, index int) string {
-	argument := Argument(node, index)
+	return ArgumentValue(Argument(node, index))
+}
+
+// ArgumentValue returns the complete expression text of one argument node,
+// without the label a named argument carries. Use it to tell a whole value
+// apart from a fragment of it: a caller that matched a descendant cannot
+// otherwise see that Foo::BAR is only half of Foo::BAR . Baz::QUX.
+func ArgumentValue(argument *syntax.Node) string {
 	if argument == nil {
 		return ""
 	}

--- a/internal/symfony/php_routes.go
+++ b/internal/symfony/php_routes.go
@@ -43,13 +43,14 @@ func parsePHPRoutesWithLineIndex(filePath string, root *phpsyntax.Node, content 
 		return nil
 	}
 	namespace := phpquery.Namespace(root)
+	resolver := php.NewNameResolver(root)
 	var routes []Route
 
 	for _, classNode := range phpquery.Classes(root) {
 		className := phpquery.ClassName(classNode)
 		basePath := ""
 		for _, attribute := range routeAttributes(classNode) {
-			classRoute := extractRouteFromAttribute(attribute, lineIndex)
+			classRoute := extractRouteFromAttribute(attribute, lineIndex, resolver)
 			if basePath == "" {
 				basePath = classRoute.Path
 			}
@@ -61,7 +62,7 @@ func parsePHPRoutesWithLineIndex(filePath string, root *phpsyntax.Node, content 
 				continue
 			}
 			for _, attribute := range routeAttributes(methodNode) {
-				route := extractRouteFromAttribute(attribute, lineIndex)
+				route := extractRouteFromAttribute(attribute, lineIndex, resolver)
 				if basePath != "" && route.Path != "" {
 					route.Path = joinRoutePath(basePath, route.Path)
 				}
@@ -71,7 +72,8 @@ func parsePHPRoutesWithLineIndex(filePath string, root *phpsyntax.Node, content 
 				}
 				route.Controller = controller
 				route.FilePath = filePath
-				if route.Name != "" || route.Path != "" {
+				if route.Name != "" || route.NameConstant != "" ||
+					route.Path != "" {
 					routes = append(routes, route)
 				}
 			}
@@ -85,7 +87,7 @@ func parsePHPRoutesWithLineIndex(filePath string, root *phpsyntax.Node, content 
 				!isRouteAttribute(attribute) {
 				continue
 			}
-			route := extractRouteFromAttribute(attribute, lineIndex)
+			route := extractRouteFromAttribute(attribute, lineIndex, resolver)
 			route.FilePath = filePath
 			if route.Name != "" || route.Path != "" {
 				routes = append(routes, route)
@@ -123,7 +125,11 @@ func isRouteAttribute(attribute *phpsyntax.Node) bool {
 	return name == "Route"
 }
 
-func extractRouteFromAttribute(node *phpsyntax.Node, lineIndex *phpsyntax.LineIndex) Route {
+func extractRouteFromAttribute(
+	node *phpsyntax.Node,
+	lineIndex *phpsyntax.LineIndex,
+	resolver *php.NameResolver,
+) Route {
 	var route Route
 	if node == nil {
 		return route
@@ -141,6 +147,13 @@ func extractRouteFromAttribute(node *phpsyntax.Node, lineIndex *phpsyntax.LineIn
 		}
 		value := firstStringValue(argument)
 		if value == "" {
+			// Symfony accepts any constant expression for `name`, and
+			// Shopware core names most routes that way. The value lives in
+			// another file, so record the reference and let a consumer with
+			// the PHP index resolve it.
+			if phpquery.ArgumentName(argument) == "name" {
+				route.NameConstant = phpRouteConstantReference(argument, resolver)
+			}
 			continue
 		}
 		switch phpquery.ArgumentName(argument) {
@@ -161,6 +174,39 @@ func extractRouteFromAttribute(node *phpsyntax.Node, lineIndex *phpsyntax.LineIn
 		}
 	}
 	return route
+}
+
+// phpRouteConstantReference returns a `Fully\Qualified\Class::CONSTANT`
+// reference for a route argument written as a class constant. Returns "" for
+// anything else, including `Foo::class`, which names a controller rather than
+// a route.
+func phpRouteConstantReference(
+	argument *phpsyntax.Node,
+	resolver *php.NameResolver,
+) string {
+	if argument == nil || resolver == nil {
+		return ""
+	}
+	// `Foo::BAR` parses as a member access here, not a scoped access; match
+	// both, as phpquery.ScopedAccessClass does.
+	for _, access := range phpquery.Nodes(
+		argument,
+		phpsyntax.PhpScopedAccess,
+		phpsyntax.PhpMemberAccess,
+	) {
+		text := strings.Join(strings.Fields(access.Text()), "")
+		separator := strings.LastIndex(text, "::")
+		if separator <= 0 {
+			continue
+		}
+		class := text[:separator]
+		member := text[separator+2:]
+		if class == "" || member == "" || strings.EqualFold(member, "class") {
+			continue
+		}
+		return strings.TrimPrefix(resolver.Resolve(class), "\\") + "::" + member
+	}
+	return ""
 }
 
 func firstStringValue(node *phpsyntax.Node) string {

--- a/internal/symfony/php_routes.go
+++ b/internal/symfony/php_routes.go
@@ -187,6 +187,11 @@ func phpRouteConstantReference(
 	if argument == nil || resolver == nil {
 		return ""
 	}
+	// The constant has to be the whole value. `Names::PREFIX . Names::DETAIL`
+	// names a route this cannot evaluate, and taking the first half would key
+	// the route under a name no reference uses while the real one still
+	// reports as missing.
+	value := collapseRouteExpression(phpquery.ArgumentValue(argument))
 	// `Foo::BAR` parses as a member access here, not a scoped access; match
 	// both, as phpquery.ScopedAccessClass does.
 	for _, access := range phpquery.Nodes(
@@ -194,7 +199,10 @@ func phpRouteConstantReference(
 		phpsyntax.PhpScopedAccess,
 		phpsyntax.PhpMemberAccess,
 	) {
-		text := strings.Join(strings.Fields(access.Text()), "")
+		text := collapseRouteExpression(access.Text())
+		if text != value {
+			continue
+		}
 		separator := strings.LastIndex(text, "::")
 		if separator <= 0 {
 			continue
@@ -207,6 +215,12 @@ func phpRouteConstantReference(
 		return strings.TrimPrefix(resolver.Resolve(class), "\\") + "::" + member
 	}
 	return ""
+}
+
+// collapseRouteExpression removes the whitespace a multi-line attribute puts
+// inside an expression, so a node's text can be compared to its argument's.
+func collapseRouteExpression(text string) string {
+	return strings.Join(strings.Fields(text), "")
 }
 
 func firstStringValue(node *phpsyntax.Node) string {

--- a/internal/symfony/php_routes_test.go
+++ b/internal/symfony/php_routes_test.go
@@ -204,3 +204,34 @@ func parsePHPFile(filePath string) (*phpsyntax.Node, []byte) {
 
 	return phpparser.ParseBytes(content).Tree.Root, content
 }
+
+func TestExtractRouteNamedByClassConstant(t *testing.T) {
+	// Symfony accepts a constant expression for `name`, and Shopware core
+	// names most routes that way. The value lives in another file, so the
+	// parser records the reference with the class resolved through the file's
+	// imports; ResolveConstantRouteName turns it into a name later.
+	filePath := "testdata/controller_constant_name.php"
+	node, content := parsePHPFile(filePath)
+
+	routes := parsePHPRoutes(filePath, node, content)
+	require.Len(t, routes, 1)
+
+	assert.Equal(t, "", routes[0].Name)
+	assert.Equal(
+		t,
+		"App\\Seo\\ProductPageSeoUrlRoute::ROUTE_NAME",
+		routes[0].NameConstant,
+	)
+	assert.Equal(t, "/detail/{productId}", routes[0].Path)
+}
+
+func TestExtractRouteIgnoresClassConstantForControllerNames(t *testing.T) {
+	// `Foo::class` names a controller, not a route, and must not be mistaken
+	// for a route name reference.
+	filePath := "testdata/controller.php"
+	node, content := parsePHPFile(filePath)
+
+	for _, route := range parsePHPRoutes(filePath, node, content) {
+		assert.Equal(t, "", route.NameConstant, route.Name)
+	}
+}

--- a/internal/symfony/php_routes_test.go
+++ b/internal/symfony/php_routes_test.go
@@ -225,6 +225,21 @@ func TestExtractRouteNamedByClassConstant(t *testing.T) {
 	assert.Equal(t, "/detail/{productId}", routes[0].Path)
 }
 
+func TestExtractRouteIgnoresConcatenatedConstantNames(t *testing.T) {
+	// `RouteNames::PREFIX . RouteNames::DETAIL` is a name this cannot
+	// evaluate. Recording the first half would key the route under a name no
+	// reference uses while the real one still reported as missing.
+	filePath := "testdata/controller_concatenated_name.php"
+	node, content := parsePHPFile(filePath)
+
+	routes := parsePHPRoutes(filePath, node, content)
+	require.Len(t, routes, 1)
+
+	assert.Equal(t, "", routes[0].Name)
+	assert.Equal(t, "", routes[0].NameConstant)
+	assert.Equal(t, "/detail/{productId}", routes[0].Path)
+}
+
 func TestExtractRouteIgnoresClassConstantForControllerNames(t *testing.T) {
 	// `Foo::class` names a controller, not a route, and must not be mistaken
 	// for a route name reference.

--- a/internal/symfony/route_constant_names.go
+++ b/internal/symfony/route_constant_names.go
@@ -1,0 +1,70 @@
+package symfony
+
+import (
+	"strings"
+
+	"github.com/shopware/shopware-lsp/internal/php/semantic"
+	"github.com/shopware/shopware-lsp/internal/php/types"
+)
+
+// ClassConstantLookup is the slice of the PHP index needed to resolve a route
+// name written as a class constant. *php.PHPIndex satisfies it.
+type ClassConstantLookup interface {
+	Constants(className string) []semantic.Symbol
+}
+
+// ResolveConstantRouteName returns the literal route name behind a
+// `Class::CONSTANT` reference, or "" when it cannot be resolved.
+//
+// Symfony accepts any constant expression for a route's name, and Shopware
+// core uses that for most of its routes:
+//
+//	#[Route(name: ProductPageSeoUrlRoute::ROUTE_NAME, ...)]
+//
+// The constant lives in a different file from the controller, and indexers see
+// one file at a time with no second pass, so the name cannot be resolved while
+// indexing. It is resolved here instead, by callers that hold the PHP index.
+func ResolveConstantRouteName(
+	reference string,
+	lookup ClassConstantLookup,
+) string {
+	if lookup == nil {
+		return ""
+	}
+	className, constantName, found := strings.Cut(reference, "::")
+	if !found || className == "" || constantName == "" {
+		return ""
+	}
+	for _, constant := range lookup.Constants(className) {
+		if constant.Name != constantName {
+			continue
+		}
+		// Only a literal is usable. A constant computed at runtime, or one
+		// whose type widened to plain string, has no name to match against.
+		if constant.Type.Kind() != types.LiteralStringKind {
+			return ""
+		}
+		return constant.Type.Name()
+	}
+	return ""
+}
+
+// ResolveConstantRouteNames fills in Name for every route that carries only a
+// constant reference, dropping those that stay unresolved. Routes with a
+// literal name pass through untouched.
+func ResolveConstantRouteNames(
+	routes []Route,
+	lookup ClassConstantLookup,
+) []Route {
+	resolved := make([]Route, 0, len(routes))
+	for _, route := range routes {
+		if route.Name == "" && route.NameConstant != "" {
+			route.Name = ResolveConstantRouteName(route.NameConstant, lookup)
+		}
+		if route.Name == "" {
+			continue
+		}
+		resolved = append(resolved, route)
+	}
+	return resolved
+}

--- a/internal/symfony/route_constant_names_test.go
+++ b/internal/symfony/route_constant_names_test.go
@@ -1,0 +1,110 @@
+package symfony
+
+import (
+	"testing"
+
+	"github.com/shopware/shopware-lsp/internal/php/semantic"
+	"github.com/shopware/shopware-lsp/internal/php/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubConstantLookup map[string][]semantic.Symbol
+
+func (s stubConstantLookup) Constants(className string) []semantic.Symbol {
+	return s[className]
+}
+
+func literalConstant(name, value string) semantic.Symbol {
+	return semantic.Symbol{
+		Kind: semantic.ClassConstantSymbol,
+		Name: name,
+		Type: types.LiteralString(value),
+	}
+}
+
+func TestResolveConstantRouteName(t *testing.T) {
+	lookup := stubConstantLookup{
+		"App\\Seo\\ProductPageSeoUrlRoute": {
+			literalConstant("ROUTE_NAME", "frontend.detail.page"),
+			literalConstant("OTHER", "frontend.other"),
+		},
+		"App\\Computed": {
+			// A constant the inference could not narrow to a literal has no
+			// name to match a route against.
+			{Kind: semantic.ClassConstantSymbol, Name: "ROUTE_NAME", Type: types.String()},
+		},
+	}
+
+	for name, testCase := range map[string]struct {
+		reference string
+		expected  string
+	}{
+		"resolves a literal string constant": {
+			reference: "App\\Seo\\ProductPageSeoUrlRoute::ROUTE_NAME",
+			expected:  "frontend.detail.page",
+		},
+		"picks the named constant, not the first": {
+			reference: "App\\Seo\\ProductPageSeoUrlRoute::OTHER",
+			expected:  "frontend.other",
+		},
+		"unknown class": {
+			reference: "App\\Missing::ROUTE_NAME",
+			expected:  "",
+		},
+		"unknown constant on a known class": {
+			reference: "App\\Seo\\ProductPageSeoUrlRoute::ABSENT",
+			expected:  "",
+		},
+		"non-literal constant": {
+			reference: "App\\Computed::ROUTE_NAME",
+			expected:  "",
+		},
+		"not a class constant reference": {
+			reference: "frontend.detail.page",
+			expected:  "",
+		},
+		"empty": {
+			reference: "",
+			expected:  "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				testCase.expected,
+				ResolveConstantRouteName(testCase.reference, lookup),
+			)
+		})
+	}
+}
+
+func TestResolveConstantRouteNameWithoutLookup(t *testing.T) {
+	// The CLI and tests can reach this without a PHP index.
+	assert.Equal(t, "", ResolveConstantRouteName("App\\Foo::BAR", nil))
+}
+
+func TestResolveConstantRouteNames(t *testing.T) {
+	lookup := stubConstantLookup{
+		"App\\Seo\\ProductPageSeoUrlRoute": {
+			literalConstant("ROUTE_NAME", "frontend.detail.page"),
+		},
+	}
+
+	resolved := ResolveConstantRouteNames([]Route{
+		{Name: "frontend.account.address.page", Path: "/account/address"},
+		{NameConstant: "App\\Seo\\ProductPageSeoUrlRoute::ROUTE_NAME", Path: "/detail"},
+		{NameConstant: "App\\Missing::ROUTE_NAME", Path: "/gone"},
+		{Path: "/nameless"},
+	}, lookup)
+
+	// A literal name passes through, a resolvable constant gains one, and
+	// anything still nameless is dropped rather than matching "".
+	assert.Equal(t, []Route{
+		{Name: "frontend.account.address.page", Path: "/account/address"},
+		{
+			Name:         "frontend.detail.page",
+			NameConstant: "App\\Seo\\ProductPageSeoUrlRoute::ROUTE_NAME",
+			Path:         "/detail",
+		},
+	}, resolved)
+}

--- a/internal/symfony/route_indexer.go
+++ b/internal/symfony/route_indexer.go
@@ -127,10 +127,31 @@ func (idx *RouteIndexer) ID() string {
 	return "symfony.route"
 }
 
+// GetRoutes returns every route that has a literal name. A route named by a
+// class constant is left out: the constant lives in another file, so only a
+// caller holding the PHP index can evaluate it, and a route with no name would
+// otherwise reach completion, workspace symbols, and catalogs as a blank
+// entry. Those callers use ResolvedRoutes instead.
 func (idx *RouteIndexer) GetRoutes() (RouteList, error) {
-	routes, err := idx.dataIndexer.GetAllValues()
-	if err != nil || idx.compiledRoutes == nil {
-		return routes, err
+	return idx.routes(nil)
+}
+
+// ResolvedRoutes returns what GetRoutes returns plus the routes whose name is
+// a class constant, with lookup supplying the literal behind each one.
+func (idx *RouteIndexer) ResolvedRoutes(
+	lookup ClassConstantLookup,
+) (RouteList, error) {
+	return idx.routes(lookup)
+}
+
+func (idx *RouteIndexer) routes(lookup ClassConstantLookup) (RouteList, error) {
+	stored, err := idx.dataIndexer.GetAllValues()
+	if err != nil {
+		return nil, err
+	}
+	routes := RouteList(ResolveConstantRouteNames(stored, lookup))
+	if idx.compiledRoutes == nil {
+		return routes, nil
 	}
 	seen := make(map[string]struct{}, len(routes))
 	for _, route := range routes {

--- a/internal/symfony/route_indexer.go
+++ b/internal/symfony/route_indexer.go
@@ -13,12 +13,18 @@ import (
 
 // Route represents a Symfony route from YAML, PHP, or other sources
 type Route struct {
-	Name       string
-	Path       string
-	Controller string
-	Methods    []string
-	FilePath   string
-	Line       int
+	Name string
+	// NameConstant holds a `Fully\Qualified\Class::CONSTANT` reference when
+	// the route name is a class constant rather than a literal. Resolving it
+	// needs another file's symbols, which the indexer does not have, so
+	// consumers holding the PHP index resolve it at query time via
+	// ResolveConstantRouteName.
+	NameConstant string
+	Path         string
+	Controller   string
+	Methods      []string
+	FilePath     string
+	Line         int
 }
 
 // Parameters returns path placeholders in source order. Symfony's inline
@@ -613,13 +619,19 @@ func (idx *RouteIndexer) indexPhp(file *indexer.ParsedFile) error {
 
 	batchSave := map[string]map[string]Route{file.Path: {}}
 	for _, route := range parsedRoutes {
-		if route.Name == "" {
+		// A constant-named route has no literal name yet; key it by the
+		// reference so it survives indexing and can be resolved later.
+		key := route.Name
+		if key == "" {
+			key = route.NameConstant
+		}
+		if key == "" {
 			continue
 		}
 		if _, ok := batchSave[route.FilePath]; !ok {
 			batchSave[route.FilePath] = make(map[string]Route)
 		}
-		batchSave[route.FilePath][route.Name] = route
+		batchSave[route.FilePath][key] = route
 	}
 	addRouteWorkspaceSymbols(file, parsedRoutes)
 

--- a/internal/symfony/route_indexer_test.go
+++ b/internal/symfony/route_indexer_test.go
@@ -122,3 +122,46 @@ func requireRouteNamed(t *testing.T, routes []Route, name string) {
 	}
 	t.Fatalf("route %q not found in %#v", name, routes)
 }
+
+func TestRouteIndexerKeepsUnresolvedRoutesOutOfGetRoutes(t *testing.T) {
+	routeIndex, err := NewRouteIndexer(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, routeIndex.Close()) })
+	require.NoError(t, routeIndex.Index(indexer.NewParsedFile(
+		"/project/src/Controller/ProductController.php",
+		[]byte(`<?php
+namespace App\Controller;
+use App\Seo\ProductPageSeoUrlRoute;
+class ProductController
+{
+    #[Route(path: '/detail/{productId}', name: ProductPageSeoUrlRoute::ROUTE_NAME)]
+    public function detail(): void {}
+
+    #[Route(path: '/address', name: 'frontend.account.address.page')]
+    public function address(): void {}
+}`),
+	)))
+
+	// A route whose name is still a constant would reach completion and
+	// workspace symbols as a blank entry, so only the literal one is offered.
+	routes, err := routeIndex.GetRoutes()
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+	require.Equal(t, "frontend.account.address.page", routes[0].Name)
+
+	resolved, err := routeIndex.ResolvedRoutes(stubConstantLookup{
+		"App\\Seo\\ProductPageSeoUrlRoute": {
+			literalConstant("ROUTE_NAME", "frontend.detail.page"),
+		},
+	})
+	require.NoError(t, err)
+	requireRouteNamed(t, resolved, "frontend.detail.page")
+	requireRouteNamed(t, resolved, "frontend.account.address.page")
+
+	// Without a lookup the constant stays unresolved and is dropped, rather
+	// than being offered under an empty name.
+	unresolved, err := routeIndex.ResolvedRoutes(nil)
+	require.NoError(t, err)
+	require.Len(t, unresolved, 1)
+	require.Equal(t, "frontend.account.address.page", unresolved[0].Name)
+}

--- a/internal/symfony/testdata/controller_concatenated_name.php
+++ b/internal/symfony/testdata/controller_concatenated_name.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Seo\RouteNames;
+
+class ProductController
+{
+    #[Route(
+        path: '/detail/{productId}',
+        name: RouteNames::PREFIX . RouteNames::DETAIL,
+        methods: ['GET']
+    )]
+    public function index(): void
+    {
+    }
+}

--- a/internal/symfony/testdata/controller_constant_name.php
+++ b/internal/symfony/testdata/controller_constant_name.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Seo\ProductPageSeoUrlRoute;
+
+class ProductController
+{
+    #[Route(
+        path: '/detail/{productId}',
+        name: ProductPageSeoUrlRoute::ROUTE_NAME,
+        methods: ['GET']
+    )]
+    public function index(): void
+    {
+    }
+}


### PR DESCRIPTION
Symfony accepts any constant expression for a route's name, and Shopware core names most of its routes that way:

```php
#[Route(
    path: '/detail/{productId}',
    name: ProductPageSeoUrlRoute::ROUTE_NAME,
    methods: ['GET']
)]
```

`extractRouteFromAttribute` only read `PhpString` nodes, so the name came back empty, the route never entered the index, and every reference to it was reported missing.

On a `shopware/shopware` trunk checkout this shows up as three errors on shipped, correct code:

```
src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig:13:31:
  error: Route 'frontend.detail.page' not found [symfony.route.missing]
  ... and lines 44, 71
```

A user seeing that reasonably concludes the server is broken.

## Why it is resolved at query time

The value cannot be resolved while indexing. The constant lives in a different file from the controller, `Indexer` works one file at a time, and there is no second pass — so on a cold index the controller can be reached before the class defining its constant.

So the parser records the *reference*, with the class resolved through the file's own imports, and consumers holding the PHP index resolve it when asked. That is also where `AGENTS.md` says request-time work belongs ("Request-time features must query existing indexes or the current open document"), and no new scanning is introduced.

The type system already knows the value, so resolution is a lookup rather than a re-parse:

```
$ shopware-lsp hover src/Storefront/Controller/ProductController.php:58:41
const ROUTE_NAME: "frontend.detail.page"
```

## Changes

- **`php_routes.go`** records `Fully\Qualified\Class::CONSTANT` into a new `Route.NameConstant` when `name:` is not a string. `Foo::class` is skipped — that names a controller, not a route. `Foo::BAR` parses as `PhpMemberAccess` rather than `PhpScopedAccess`, so both are matched, as `phpquery.ScopedAccessClass` already does.
- **`route_indexer.go`** keys such routes by the reference so they survive indexing instead of being dropped for having no name.
- **`IndexVersion` 171 → 172**, because the persisted shape changed. The `assert.Equal(t, 171, IndexVersion)` tripwire moves with it.
- **`ResolveConstantRouteName`** reads the literal off the constant's type via a one-method `ClassConstantLookup` interface that `*php.PHPIndex` already satisfies.
- **`RouteAnalyzer`** resolves before reporting anything missing, on the existing miss path where `GetRoutes()` is already loaded lazily — so the cost is paid only when a route looks absent.

## Verification

Against a `shopware/shopware` trunk checkout with a clean index:

| case | before | after |
|---|---|---|
| `seoUrl('frontend.detail.page')` — constant-named | error | clean |
| `seoUrl('frontend.account.address.page')` — literal-named | clean | clean |
| `seoUrl('frontend.totally.made.up')` — absent | error | error |

That third row is the one that matters: the diagnostic still fires for genuinely missing routes rather than being silenced.

Both new test groups fail when the change is neutered — the parser tests when `phpRouteConstantReference` returns `""`, the resolver tests when `ResolveConstantRouteName` does.

`go test ./internal/...` passes except for `TestProjectRouteIndexerReloadsCompiledRoutes`, which **also fails on `main`** — reproduced twice in a clean worktree at 029c9bb, so it is unrelated to this change. `go test -race` on the changed packages and `golangci-lint run` are clean.

## Deliberately out of scope

- **Route completion and go-to-definition still ignore constant-named routes.** `ResolveConstantRouteNames` is exported so they can adopt it, but wiring those paths is a larger change and deserves its own review. Happy to follow up.
- **Only the named `name:` argument is handled**, not a positional one. Symfony allows `#[Route('/path', SomeClass::NAME)]`; nothing in core uses it, and handling it would mean guessing at positional intent.
- **Constants that do not narrow to a literal** resolve to nothing and are dropped, rather than matching an empty name.

Found while running the server under Zed, where these diagnostics surface on a plain trunk checkout.
