### PR TITLE
fix(twig): index templates the loader serves but Twig does not parse

### DIFF
--- a/internal/indexer/version.go
+++ b/internal/indexer/version.go
@@ -11,7 +11,7 @@ import (
 // IndexVersion is the current version of persisted index contents. Bump it
 // whenever a schema change or extraction-semantics change requires existing
 // workspace caches to be rebuilt.
-const IndexVersion = 171
+const IndexVersion = 172
 
 const versionFileName = "index_version"
 const configurationFingerprintFileName = "configuration_fingerprint"

--- a/internal/indexer/version_test.go
+++ b/internal/indexer/version_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCheckAndMigrateCache_FreshCache(t *testing.T) {
-	assert.Equal(t, 171, IndexVersion)
+	assert.Equal(t, 172, IndexVersion)
 	cacheDir := t.TempDir()
 
 	// Fresh cache should be marked as cleared (needs rebuild)

--- a/internal/twig/indexer.go
+++ b/internal/twig/indexer.go
@@ -255,8 +255,42 @@ func (idx *TwigIndexer) Index(file *indexer.ParsedFile) error {
 	case ".yaml", ".yml":
 		return idx.indexYAMLGlobals(file)
 	default:
+		return idx.indexTemplateAsset(file)
+	}
+}
+
+// ShouldEnterDirectory keeps template assets to directories the scanner walks
+// anyway. Template roots are part of a normal scan; a skipped directory such as
+// var/cache holds no template a project can address.
+func (idx *TwigIndexer) ShouldEnterDirectory(string) bool {
+	return false
+}
+
+// ShouldIndexPath adds the template files the language registry does not claim,
+// such as the .svg views Symfony's profiler includes. Files it does claim are
+// already scanned, so they reach Index without help.
+func (idx *TwigIndexer) ShouldIndexPath(path string) bool {
+	return !indexer.IsScannedPath(path) && IsTemplateAssetPath(path)
+}
+
+// indexTemplateAsset records the names a non-Twig template can be addressed by.
+// Nothing is parsed: the file is data to whatever template includes it, so only
+// its existence under a template root is indexed. PHP and YAML files are left
+// out on purpose — under Resources/views they are classes and configuration,
+// not templates.
+func (idx *TwigIndexer) indexTemplateAsset(parsed *indexer.ParsedFile) error {
+	if !IsTemplateAssetPath(parsed.Path) {
 		return nil
 	}
+	file := newTwigFile(parsed.Path)
+	names := make(map[string]TwigFile)
+	for _, name := range TemplateNames(parsed.Path) {
+		names[name] = *file
+	}
+	return idx.twigFileIndex.BatchSaveItemsIn(
+		parsed.Mutation(),
+		map[string]map[string]TwigFile{parsed.Path: names},
+	)
 }
 
 func (idx *TwigIndexer) indexYAMLGlobals(
@@ -336,7 +370,7 @@ func (idx *TwigIndexer) saveGlobals(
 
 func (idx *TwigIndexer) indexTwig(parsed *indexer.ParsedFile) error {
 	path := parsed.Path
-	if strings.Contains(path, "Resources/app/administration") || strings.Contains(path, "Migration/Fixtures") || strings.Contains(path, ".phpdoc/template") {
+	if isExcludedTwigPath(path) {
 		return errors.Join(
 			idx.twigFileIndex.BatchSaveItemsIn(parsed.Mutation(), map[string]map[string]TwigFile{path: {}}),
 			idx.twigBlockIndex.BatchSaveItemsIn(parsed.Mutation(), map[string]map[string]TwigBlock{path: {}}),

--- a/internal/twig/indexer_test.go
+++ b/internal/twig/indexer_test.go
@@ -53,6 +53,55 @@ func TestTwigIndexerUsesPureGoParserThroughFileScanner(t *testing.T) {
 	require.Equal(t, templatePath, hashes[0].AbsolutePath)
 }
 
+func TestTwigIndexerIndexesTemplatesWithoutATwigExtension(t *testing.T) {
+	tempDir := t.TempDir()
+	collector := filepath.Join(
+		tempDir, "src", "Core", "Profiling", "Resources", "views", "Collector",
+	)
+	require.NoError(t, os.MkdirAll(collector, 0755))
+	// Symfony's profiler includes this from db.html.twig, and Twig serves
+	// whatever sits below a loader path regardless of extension.
+	iconPath := filepath.Join(collector, "checkmark.svg")
+	require.NoError(t, os.WriteFile(iconPath, []byte(`<svg></svg>`), 0644))
+	assetPath := filepath.Join(
+		tempDir, "src", "Core", "Profiling", "Resources", "public", "checkmark.svg",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(assetPath), 0755))
+	require.NoError(t, os.WriteFile(assetPath, []byte(`<svg></svg>`), 0644))
+
+	twigIndexer, err := NewTwigIndexer(filepath.Join(tempDir, "cache"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, twigIndexer.Close()) })
+
+	fileScanner, err := indexer.NewFileScanner(
+		tempDir,
+		filepath.Join(tempDir, "scanner.db"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fileScanner.Close()) })
+	fileScanner.AddIndexer(twigIndexer)
+
+	require.NoError(t, fileScanner.IndexFiles(
+		context.Background(),
+		[]string{iconPath, assetPath},
+	))
+
+	files, err := twigIndexer.GetTwigFilesByRelPath("@Profiling/Collector/checkmark.svg")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, iconPath, files[0].Path)
+
+	// The same file outside a template root is an asset, not a template.
+	_, found, err := twigIndexer.GetTwigFileByPath(assetPath)
+	require.NoError(t, err)
+	require.False(t, found)
+
+	require.NoError(t, twigIndexer.RemovedFiles([]string{iconPath}))
+	files, err = twigIndexer.GetTwigFilesByRelPath("@Profiling/Collector/checkmark.svg")
+	require.NoError(t, err)
+	require.Empty(t, files)
+}
+
 func TestTwigIndexerStoresSymfonyTemplateAliases(t *testing.T) {
 	idx, err := NewTwigIndexer(t.TempDir())
 	require.NoError(t, err)

--- a/internal/twig/path.go
+++ b/internal/twig/path.go
@@ -7,6 +7,33 @@ import (
 	"strings"
 )
 
+// templateRootMarkers are the directories a Twig loader is pointed at. Anything
+// below one of them is addressable as a template.
+var templateRootMarkers = []string{"/Resources/views/", "/templates/"}
+
+// IsTemplateAssetPath reports whether a file lives under a template root while
+// carrying an extension other than .twig. Twig loaders serve whatever sits
+// below their paths — Symfony's profiler includes .svg views — so whether a
+// template exists must not depend on it being parseable Twig.
+func IsTemplateAssetPath(templatePath string) bool {
+	normalized := filepath.ToSlash(templatePath)
+	extension := filepath.Ext(normalized)
+	// An extension-less entry is a directory, a symlink to one, or a tooling
+	// file. A template root can hold any of those, and reading one as a
+	// template fails the whole index run.
+	if extension == "" || strings.EqualFold(extension, ".twig") ||
+		strings.HasPrefix(filepath.Base(normalized), ".") ||
+		isExcludedTwigPath(normalized) {
+		return false
+	}
+	for _, marker := range templateRootMarkers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 func ConvertToRelativePath(twigPath string) string {
 	index := strings.Index(twigPath, "Resources/views")
 	if index != -1 {
@@ -26,6 +53,16 @@ func ConvertToRelativePath(twigPath string) string {
 	}
 
 	return fmt.Sprintf("@Storefront/%s", path)
+}
+
+// isExcludedTwigPath reports whether a file uses Twig syntax without being a
+// template the Symfony loader can resolve: administration sources, migration
+// fixtures, and phpDocumentor's own templates.
+func isExcludedTwigPath(templatePath string) bool {
+	normalized := filepath.ToSlash(templatePath)
+	return strings.Contains(normalized, "Resources/app/administration") ||
+		strings.Contains(normalized, "Migration/Fixtures") ||
+		strings.Contains(normalized, ".phpdoc/template")
 }
 
 // TemplateNames returns the portable names by which Twig can address a file.

--- a/internal/twig/path_test.go
+++ b/internal/twig/path_test.go
@@ -33,3 +33,25 @@ func TestTemplateNames(t *testing.T) {
 		TemplateNames("/project/MyBundle/src/Resources/views/card.html.twig"),
 	)
 }
+
+func TestIsTemplateAssetPath(t *testing.T) {
+	assert.True(t, IsTemplateAssetPath(
+		"/project/src/Core/Profiling/Resources/views/Collector/checkmark.svg",
+	))
+	assert.True(t, IsTemplateAssetPath("/project/templates/mail/logo.svg"))
+	// Twig files take the full indexing path instead.
+	assert.False(t, IsTemplateAssetPath(
+		"/project/src/Storefront/Resources/views/storefront/base.html.twig",
+	))
+	// Not below a template root, so no loader can address it.
+	assert.False(t, IsTemplateAssetPath("/project/public/bundles/storefront/logo.svg"))
+	assert.False(t, IsTemplateAssetPath(
+		"/project/src/Administration/Resources/app/administration/src/icon.svg",
+	))
+	assert.False(t, IsTemplateAssetPath("/project/templates/.gitignore"))
+	// Shopware symlinks node_modules into a template root, and os.ReadDir
+	// reports the link as a file.
+	assert.False(t, IsTemplateAssetPath(
+		"/project/src/Storefront/Resources/views/components/node_modules",
+	))
+}


### PR DESCRIPTION
Closes the second item of #64. #68 covers the first. The third is now deliberately not here — see the bottom.

A Twig loader serves whatever sits below its paths, but only `.twig` files entered the template index, so whether a template existed depended on it being parseable Twig. Symfony's profiler collectors include `.svg` views routinely, and the shipped file sitting next to the template that includes it reported as missing:

```
src/Core/Profiling/Resources/views/Collector/db.html.twig:14:20:
  error: Template '@Profiling/Collector/checkmark.svg' not found [twig.template.missing]
```

`checkmark.svg` is right there in the same directory.

## Changes

- **`Index`** routes files below a template root that it does not otherwise handle to `indexTemplateAsset`, which records the names `TemplateNames` produces and nothing else. Nothing is parsed — to the template including it the file is data — so this costs one row per file and no CST. `.php` and `.yaml` keep their own meaning under `Resources/views`; there they are classes and configuration, not templates.
- **`ShouldIndexPath`** (`SupplementalPathIndexer`) admits the files the language registry does not claim, since a `.svg` is not otherwise scanned. `ShouldEnterDirectory` returns false: template roots are walked anyway, and no skipped directory holds an addressable template. `SupplementalSyntaxIndexer` is deliberately not implemented, so none of these files are pre-parsed.
- **Extension-less entries are skipped.** Found the hard way: Shopware symlinks `node_modules` into `src/Storefront/Resources/views/components`, `os.ReadDir` reports the link as a file rather than a directory, and reading it as a template failed the whole index run with `is a directory`. Any supplemental indexer accepting an extension-less path below a walked directory can hit this.
- **`isExcludedTwigPath`** is extracted from `indexTwig` so both paths skip administration sources, migration fixtures, and phpDocumentor templates identically.
- **`IndexVersion` 171 → 172**, because existing caches hold the old set of names. The tripwire in `version_test.go` moves with it. #68 also bumps to 172, so whichever lands second needs a trivial rebase.

## Verification

`shopware-lsp -root . -json check src/` over a `shopware/shopware` trunk checkout, cold index, before and after:

| | before | after |
|---|---|---|
| `twig.template.missing` | 36 | 20 |
| every other diagnostic code | 771 | 771 |
| new diagnostics of any kind | — | 0 |

The 16 that clear are the `.svg` includes in `@Profiling` and `@Elasticsearch`.

The 20 that stay are the point of the table. 19 are `@WebProfiler/...`, which needs the namespace fix below, and one is `source('@Storefront/assets/icon/solid/arrow-medium-right.svg')` in `storefront/layout/breadcrumb.html.twig` — that file exists only under `Resources/app/storefront/dist/assets/`, which is not a registered `@Storefront` path in the checkout. So the rule still fires where a name genuinely does not resolve, rather than being blanket-silenced.

Cold index over `src/` is unchanged within run-to-run noise, as expected for ~130 extra rows.

The indexer test fails when `IsTemplateAssetPath` is made to return false. `go test ./internal/...` passes except `TestProjectRouteIndexerReloadsCompiledRoutes`, which **also fails on `main`** — reproduced in a clean worktree at 029c9bb, unrelated. `go test -race ./internal/twig ./internal/indexer` and `golangci-lint run` are clean. The VS Code checks were not run: no protocol shape, configuration, command, startup, or MCP wiring changed.

## Deliberately out of scope

- **Vendor bundle Twig namespaces — item 3 of #64 — are no longer in this PR.** An earlier revision derived `@WebProfiler` from the `web-profiler-bundle` directory name by spelling it as PHP spells a class and dropping a `Bundle` suffix. Review pointed out that this invents a namespace when a package directory does not match its bundle class: `friendsofsymfony/user-bundle` holds `FOSUserBundle`, so the rule produces `@User` while Symfony exposes `@FOSUser`. Because the missing-template diagnostic treats any indexed name as proof a template exists, that silences the rule for a namespace that does not exist, which is the same class of lie as the false positive this PR removes. A filesystem probe for the bundle class does not rescue it either — `vendor/shopware/administration` has no PHP file at its package root. Getting it right means the bundle index knowing Symfony bundles by class and namespaces resolving at query time, which is the layer question #64 already asked the maintainers to weigh in on. Discussion continues there.
- **`.html` files below a template root are now indexed by name only**, not fully. They are a template Twig can load, so the name belongs in the index, but blocks and macros inside one are not extracted. `internal/language` still keeps `.html` out of workspace scans on purpose, and lifting that is a bigger decision than this fix.
